### PR TITLE
check target path before adding file name

### DIFF
--- a/src/komparemodellist.cpp
+++ b/src/komparemodellist.cpp
@@ -395,8 +395,6 @@ bool KompareModelList::saveDestination(DiffModel* model)
         qCDebug(LIBKOMPAREDIFF2) << "tmp                 : " << tmp;
         KIO::UDSEntry entry;
         QUrl fullDestinationPath = m_info->destination;
-        fullDestinationPath.setPath(fullDestinationPath.path() + QLatin1Char('/') + tmp);
-        qCDebug(LIBKOMPAREDIFF2) << "fullDestinationPath : " << fullDestinationPath;
         KIO::StatJob* statJob = KIO::stat(fullDestinationPath);
         if (!statJob->exec())
         {
@@ -408,6 +406,8 @@ bool KompareModelList::saveDestination(DiffModel* model)
                 return false;
             }
         }
+        fullDestinationPath.setPath(fullDestinationPath.path() + QLatin1Char('/') + tmp);
+        qCDebug(LIBKOMPAREDIFF2) << "fullDestinationPath : " << fullDestinationPath;
         KIO::FileCopyJob* copyJob = KIO::file_copy(QUrl::fromLocalFile(temp.fileName()), fullDestinationPath, -1, KIO::Overwrite);
         result = copyJob->exec();
     }


### PR DESCRIPTION
when the target destination file (tmp) is added to the path before the KIO::mkdir call, a directory is created with the name of the target file and subsequent attempt to save the file fails with the "Could not upload the temporary file to the destination location <b>%1</b>. The temporary file is still available under ..." error.